### PR TITLE
When calling xml_escape_array, it was adding CDATA tags on numeric va…

### DIFF
--- a/framework/plugins/xml_transform.inc.php
+++ b/framework/plugins/xml_transform.inc.php
@@ -176,8 +176,12 @@ function xml_escape_array($in_data)
 		}
 		return $in_data;
 	}
-	else if ($in_data !== '') {
+	else if ($in_data !== '' && !is_numeric($in_data)) {
 		return '<![CDATA[' . strip_cdata_tags($in_data) . ']]>';
+	}
+	else if (is_numeric($in_data))
+	{
+		return $in_data;
 	}
 	else { return false; }
 }


### PR DESCRIPTION
…lues which has problems with some Javascript libraries that are expecting numbers to be casted as integers
